### PR TITLE
Update demo_multiMicChamber.m

### DIFF
--- a/demo_multiMicChamber.m
+++ b/demo_multiMicChamber.m
@@ -49,7 +49,7 @@ linkaxes(gcas, 'x')
 % identify pulse times in the manual and automatic data correspoding to the
 % same pulse in the recording with a jitte of `tolerance` seconds
 tolerance = 5/1000;%s
-[confMat, eventMat] = idPulses({pulseTimesManual, pulseTimesAutomatic}, tolerance);
+[confMat, eventMat] = idPulses(pulseTimesManual, pulseTimesAutomatic, tolerance);
 confMatNorm = confMat./sum(confMat,1);
 
 fprintf('\n')


### PR DESCRIPTION
idPulses.m takes three inputs (pulseTimesA, pulseTimesB, tolerance), of which the first two are grouped into a cell in the original code. As a result, the specified tolerance is used as pulseTimesB, leaving the actual third input, tolerance, blank. This caused the following error for me:

Error using vertcat
Dimensions of matrices being concatenated are not consistent.

Error in idPulses (line 9)
pulseTimes = [pulseTimesA; pulseTimesB];

Error in demo_multiMicChamber (line 52)
[confMat, eventMat] = idPulses({pulseTimesManual, pulseTimesAutomatic},
tolerance);

The same holds for demo_singleMicChamber.m